### PR TITLE
Refactor settings panel toggle handling and improve language selector UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -346,11 +346,21 @@ tbody .fullTd {
 }
 
 .keydorp-plus-change-language {
+    display: inline-block;
+    height: 34px;
+    cursor: pointer;
+    filter: opacity(0.5);
     transition: 0.25s;
 }
 
-.keydorp-plus-change-language:hover {
+.keydorp-plus-change-language:hover,
+.keydorp-plus-change-language.active {
     filter: opacity(1) !important;
+}
+
+.keydorp-plus-change-language.active {
+    border: 1px solid gold;
+    border-radius: 4px;
 }
 
 div.hidden.overflow-hidden.md\:block.bg-navy-700 {


### PR DESCRIPTION
## Summary
- Centralize checkbox logic in settings panel using new `attachToggle` helper
- Highlight active language and consolidate styling from inline to CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689411e82a48833289ee2907ce172677