### PR TITLE
refactor: enhance utilities and fetch accuracy

### DIFF
--- a/js/giveawaysList.js
+++ b/js/giveawaysList.js
@@ -106,7 +106,7 @@ const refreshGiveawaysPanel = async(panelText) => {
   if(!config?.active) return;
 
   const index = await getIndexData();
-  let giveawaysHistory = await getStorageData('local', 'giveawaysHistory');
+  let giveawaysHistory = await getStorageData('local', 'giveawaysHistory', []);
 
   const userSkins = await getUserSkinsData(config?.token); 
   const giveawayWinnersTab = userSkins?.length !== 0 ? userSkins?.filter(el => el?.sourceType == 'giveaway') : [];


### PR DESCRIPTION
## Summary
- improve fetch utility with timeout and better query handling
- add defaults and documentation to storage helpers
- ensure giveaway history defaults to empty array

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894995699848332a9096061cb9da111