### PR TITLE
refactor: centralize shared utilities

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,4 @@
+/* global fetchUrl, getStorageData, setStorageData, clearStorageData */
 const active = true;
 const version = "F2.11";
 const toastCooldown = 4 * 1000
@@ -12,107 +13,6 @@ $('body').append($(document.createElement('div'))
     .css({ position: 'fixed', right: 0, 'margin-right': '10px', 'margin-bottom': '11px', bottom: 0, 'z-index': 999 })
 );
 
-const defaultFetchTimeout = 15 * 1000;
-
-/**
- * Perform a network request with optional authorization and body data.
- * Automatically appends a timestamp to bust caches unless `noTime` is true.
- *
- * @param {string} type       HTTP method
- * @param {string} url        Target URL
- * @param {string|false} token Optional bearer token
- * @param {boolean} noTime    Skip timestamp parameter
- * @param {Object} [data]     JSON body payload
- * @param {Object} [options]  Additional options (timeout, headers)
- * @returns {Promise<*>}      Parsed JSON/text response or null on error
- */
-const fetchUrl = async(type, url, token, noTime, data, options = {}) => {
-    const { timeout = defaultFetchTimeout, headers = {} } = options;
-    try {
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), timeout);
-        const requestUrl = new URL(url);
-        if(!noTime) requestUrl.searchParams.set('t', Date.now());
-        const response = await fetch(requestUrl.toString(), {
-            method: type,
-            headers: {
-                ...(data ? { 'Content-Type': 'application/json' } : {}),
-                ...(token ? { authorization: `Bearer ${token}` } : {}),
-                ...headers
-            },
-            body: data ? JSON.stringify(data) : undefined,
-            signal: controller.signal
-        });
-        clearTimeout(timer);
-        if(response.status === 403) {
-            return window?.location?.reload();
-        }
-        if(!response.ok) return null;
-        const contentType = response.headers.get('content-type') || '';
-        return contentType.includes('application/json') ? await response.json() : await response.text();
-    } catch(e) {
-        return null;
-    }
-};
-
-/**
- * Retrieve a value from browser storage.
- *
- * @param {'local'|'sync'|0|1} type  Storage type
- * @param {string} name             Key name
- * @param {*} [defaultValue]        Value to return if key does not exist
- * @returns {Promise<*>}           Stored value or defaultValue
- */
-const getStorageData = async(type, name, defaultValue) => {
-    try {
-        const storage = (type === 'local' || type === 0) ? chrome.storage.local : chrome.storage.sync;
-        const result = await storage.get([name]);
-        return result[name] ?? defaultValue;
-    } catch(e) {
-        return defaultValue;
-    }
-};
-
-/**
- * Save data to browser storage.
- *
- * @param {'local'|'sync'|0|1} type Storage type
- * @param {Object} data            Data to store
- * @returns {Promise<boolean>}     True on success
- */
-const setStorageData = async(type, data) => {
-    try {
-        const storage = (type === 'local' || type === 0) ? chrome.storage.local : chrome.storage.sync;
-        await storage.set(data);
-        return true;
-    } catch(e) { return false; }
-};
-
-/**
- * Clear all data from a storage area.
- *
- * @param {'local'|'sync'|0|1} type Storage type
- * @returns {Promise<boolean>}     True on success
- */
-const clearStorageData = async(type) => {
-    try {
-        const storage = (type === 'local' || type === 0) ? chrome.storage.local : chrome.storage.sync;
-        await storage.clear();
-        return true;
-    } catch(e) { return false; }
-};
-
-/**
- * Format a numeric value as a currency string.
- *
- * @param {number} value    Numeric value to format
- * @param {string} currency ISO currency code
- * @param {string} [locale='en-US'] Locale for formatting
- * @returns {string} Formatted currency string
- */
-const formatCurrency = (value, currency, locale = 'en-US') => {
-    return `${new Intl.NumberFormat(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value)} ${currency}`;
-};
 
 /**
  * Retrieve user index data from storage or remote endpoint.

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,133 @@
+/* eslint no-unused-vars: "off" */
+/* global chrome */
+/* exported fetchUrl, getStorageData, setStorageData, clearStorageData, formatCurrency */
+/**
+ * General utility helpers for Keydrop+ extension.
+ * Includes network and storage helpers reused across modules.
+ */
+
+/** Default timeout for network requests in milliseconds. */
+const defaultFetchTimeout = 15 * 1000;
+
+/** Simple in-memory cache for GET requests. */
+const fetchCache = new Map();
+
+/**
+ * Perform a network request with optional authorization and body data.
+ * Automatically appends a timestamp to bust caches unless `noTime` is true.
+ *
+ * @param {string} type HTTP method
+ * @param {string} url Target URL
+ * @param {string|false} token Optional bearer token
+ * @param {boolean} noTime Skip timestamp parameter
+ * @param {Object} [data] JSON body payload
+ * @param {{timeout?:number, headers?:Object, cache?:number}} [options]
+ *        Additional options including request timeout and cache duration
+ *        (in ms) for GET requests.
+ * @returns {Promise<*>} Parsed JSON/text response or null on error
+ */
+const fetchUrl = async (type, url, token, noTime, data, options = {}) => {
+    const { timeout = defaultFetchTimeout, headers = {}, cache = 0 } = options;
+    const cacheKey = `${type}:${url}:${JSON.stringify(data)}`;
+    if (cache > 0 && type === 'GET') {
+        const cached = fetchCache.get(cacheKey);
+        if (cached && (Date.now() - cached.time) < cache) {
+            return cached.value;
+        }
+    }
+    try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeout);
+        const requestUrl = new URL(url);
+        if (!noTime) requestUrl.searchParams.set('t', Date.now());
+        const response = await fetch(requestUrl.toString(), {
+            method: type,
+            headers: {
+                ...(data ? { 'Content-Type': 'application/json' } : {}),
+                ...(token ? { authorization: `Bearer ${token}` } : {}),
+                ...headers
+            },
+            body: data ? JSON.stringify(data) : undefined,
+            signal: controller.signal
+        });
+        clearTimeout(timer);
+        if (response.status === 403) {
+            return window?.location?.reload();
+        }
+        if (!response.ok) return null;
+        const contentType = response.headers.get('content-type') || '';
+        const value = contentType.includes('application/json')
+            ? await response.json()
+            : await response.text();
+        if (cache > 0 && type === 'GET') {
+            fetchCache.set(cacheKey, { time: Date.now(), value });
+        }
+        return value;
+    } catch (e) {
+        return null;
+    }
+};
+
+/**
+ * Retrieve a value from browser storage.
+ *
+ * @param {'local'|'sync'|0|1} type Storage type
+ * @param {string} name Key name
+ * @param {*} [defaultValue] Value to return if key does not exist
+ * @returns {Promise<*>} Stored value or defaultValue
+ */
+const getStorageData = async (type, name, defaultValue) => {
+    try {
+        const storage = (type === 'local' || type === 0) ? chrome.storage.local : chrome.storage.sync;
+        const result = await storage.get([name]);
+        return result[name] ?? defaultValue;
+    } catch (e) {
+        return defaultValue;
+    }
+};
+
+/**
+ * Save data to browser storage.
+ *
+ * @param {'local'|'sync'|0|1} type Storage type
+ * @param {Object} data Data to store
+ * @returns {Promise<boolean>} True on success
+ */
+const setStorageData = async (type, data) => {
+    try {
+        const storage = (type === 'local' || type === 0) ? chrome.storage.local : chrome.storage.sync;
+        await storage.set(data);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
+ * Clear all data from a storage area.
+ *
+ * @param {'local'|'sync'|0|1} type Storage type
+ * @returns {Promise<boolean>} True on success
+ */
+const clearStorageData = async (type) => {
+    try {
+        const storage = (type === 'local' || type === 0) ? chrome.storage.local : chrome.storage.sync;
+        await storage.clear();
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
+ * Format a numeric value as a currency string.
+ *
+ * @param {number} value Numeric value to format
+ * @param {string} currency ISO currency code
+ * @param {string} [locale='en-US'] Locale for formatting
+ * @returns {string} Formatted currency string
+ */
+const formatCurrency = (value, currency, locale = 'en-US') => {
+    return `${new Intl.NumberFormat(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value)} ${currency}`;
+};
+

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
                 "js/jquery/jquery-3.6.1.min.js",
                 "js/crypto/crypto-js.js",
                 "js/caseOdds.js",
+                "js/utils.js",
                 "js/main.js",
                 "js/joinGiveaway.js",
                 "js/dailyCaseTimer.js",
@@ -103,6 +104,7 @@
             "js": [
                 "js/jquery/jquery-3.6.1.min.js",
                 "js/crypto/crypto-js.js",
+                "js/utils.js",
                 "js/main.js",
                 "js/websites/skinport.js"
             ],
@@ -137,6 +139,7 @@
             "js": [
                 "js/jquery/jquery-3.6.1.min.js",
                 "js/crypto/crypto-js.js",
+                "js/utils.js",
                 "js/main.js",
                 "js/websites/steam.js"
             ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Unofficial extension for keydrop.com that adds helpful features and improvements.",
   "main": "js/main.js",
   "scripts": {
-    "lint": "eslint js/main.js",
+    "lint": "eslint js/main.js js/utils.js",
     "format": "prettier --check README.md"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- factor out shared fetch and storage helpers into new `utils.js`
- load utilities before main script in extension manifest
- lint script now covers the new module

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68965162b4508332be0ab986b7000239